### PR TITLE
[test] Update pad type mocking in tests

### DIFF
--- a/static/tests/frontend/specs/api-change-text-alignment.js
+++ b/static/tests/frontend/specs/api-change-text-alignment.js
@@ -8,12 +8,13 @@ describe('ep_align - API - chande text alignment', function() {
     epSEUtils = ep_script_elements_test_helper.utils;
 
     // mock a non-ScriptDocument pad type
-    epSEUtils.setPadType('ANY_TYPE');
+    var padType = 'ANY_TYPE';
 
-    helper.newPad(function() {
+    epSEUtils.newPadWithType(function() {
       apiUtils.startListeningToApiEvents();
       done();
-    });
+    }, padType);
+
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/atest.js
+++ b/static/tests/frontend/specs/atest.js
@@ -5,9 +5,8 @@ describe("ep_align - Alignment of Text", function(){
     var epSEUtils = ep_script_elements_test_helper.utils;
 
     // mock a non-ScriptDocument pad type
-    epSEUtils.setPadType('ANY_TYPE');
-
-    helper.newPad(cb);
+    var padType = 'ANY_TYPE';
+    epSEUtils.newPadWithType(cb, padType);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/padType.js
+++ b/static/tests/frontend/specs/padType.js
@@ -66,20 +66,12 @@ describe('ep_align - pad type', function() {
 
 var ep_align_test_helper = ep_align_test_helper || {};
 ep_align_test_helper.padType = {
-  getPadTypeParamMocked: function(type) {
-    return function() {
-      return type;
-    };
-  },
   createPadWithType: function(padType, cb) {
     var self = this;
     var apiUtils = ep_align_test_helper.apiUtils;
     var epSEUtils = ep_script_elements_test_helper.utils;
 
-    // mock the pad type
-    epSEUtils.setPadType(padType);
-
-    helper.newPad(function() {
+    epSEUtils.newPadWithType(function() {
       // line needs to have some text on it
       apiUtils.startListeningToApiEvents();
 
@@ -89,7 +81,7 @@ ep_align_test_helper.padType = {
       }).done(cb);
 
       cb();
-    });
+    }, padType);
   },
   isMouseWindowVisible: function() {
     var outer$ = helper.padOuter$;


### PR DESCRIPTION
This PR updates the pad type mocking interface in the tests.

Depends on https://github.com/storytouch/ep_script_elements/pull/60.