### PR TITLE
[refactor] Update padType API

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -2,6 +2,7 @@
   "parts": [
     {
       "name": "main",
+      "pre": ["ep_script_elements/preLoader"],
       "client_hooks": {
         "aceEditEvent": "ep_align/static/js/index",
         "aceDomLineProcessLineAttributes": "ep_align/static/js/index",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "ep_align",
+  "version": "0.2.0",
+  "lockfileVersion": 1
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -3,9 +3,7 @@ var _, $, jQuery;
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 
-var utils   = require('./utils');
-var api     = require('./api');
-var padType = require('ep_script_elements/static/js/padType');
+var api = require('./api');
 
 // All our tags are block elements, so we just return them.
 var tags = ['left', 'center', 'justify', 'right'];
@@ -16,11 +14,9 @@ exports.aceRegisterBlockElements = function(){
 
 // Bind the event handler to the toolbar buttons
 exports.postAceInit = function(hook, context){
-  var thisPlugin = utils.getPluginProps();
-
   // If the pad is a ScriptDocument then do nothing..
-  //thisPlugin.padType = padType.init();
-  if (thisPlugin.padType.isScriptDocumentPad()) return false;
+  var isScriptDocumentPad = pad.plugins.ep_script_elements.padType.isScriptDocumentPad();
+  if (isScriptDocumentPad) return false;
 
   api.init(context.ace);
 
@@ -37,11 +33,9 @@ exports.postAceInit = function(hook, context){
 
 // On caret position change show the current align
 exports.aceEditEvent = function(hook, call, cb){
-  var thisPlugin = utils.getPluginProps();
-
   // If the pad is a ScriptDocument then do nothing..
-  thisPlugin.padType = padType.init();
-  if (thisPlugin.padType.isScriptDocumentPad()) return false;
+  var isScriptDocumentPad = pad.plugins.ep_script_elements.padType.isScriptDocumentPad();
+  if (isScriptDocumentPad) return false;
 
   // If it's not a click or a key event and the text hasn't changed then do nothing
   var cs = call.callstack;


### PR DESCRIPTION
This PR updates the `padType` API, using the `ep_script_elements` instance to call the pad type identifier.

Depends on https://github.com/storytouch/ep_script_elements/pull/62.
Implements part of the [card 2050](https://trello.com/c/08KTQ9HF).