### PR TITLE
[fix] Exporting inner tags

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -15,7 +15,12 @@
       "hooks": {
         "eejsBlock_editbarMenuLeft": "ep_align/index",
         "collectContentPre": "ep_align/static/js/shared",
-        "collectContentPost": "ep_align/static/js/shared",
+        "collectContentPost": "ep_align/static/js/shared"
+      }
+    },
+    {
+      "post": ["ep_script_elements/getLineHTMLForExport"],
+      "hooks": {
         "getLineHTMLForExport": "ep_align/index"
       }
     }

--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
 var eejs = require('ep_etherpad-lite/node/eejs/');
-var Changeset = require("ep_etherpad-lite/static/js/Changeset");
-var Security = require('ep_etherpad-lite/static/js/security');
+var Changeset = require('ep_etherpad-lite/static/js/Changeset');
 
-exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
-  args.content = args.content + eejs.require("ep_align/templates/editbarButtons.ejs");
+exports.eejsBlock_editbarMenuLeft = function(hook_name, args, cb) {
+  args.content = args.content + eejs.require('ep_align/templates/editbarButtons.ejs');
   return cb();
-}
+};
 
 // line, apool,attribLine,text
-exports.getLineHTMLForExport = function (hook, context) {
+exports.getLineHTMLForExport = function(hook, context) {
   var alignment = _analyzeLine(context.attribLine, context.apool);
+  var lineContent = context.lineContent;
   if (alignment) {
-    context.lineContent = "<p style='text-align:" + alignment + "'>" + Security.escapeHTML(context.text.substring(1)) + "</p>";
-    return "<p style='text-align:" + alignment + "'>" + Security.escapeHTML(context.text.substring(1)) + "</p>";
+    context.lineContent = "<p style='text-align:" + alignment + "'>" + replaceGeneralTag(lineContent) + "</p>";
   }
-}
+};
 
 function _analyzeLine(alineAttrs, apool) {
   var alignment = null;
@@ -26,4 +25,10 @@ function _analyzeLine(alineAttrs, apool) {
     }
   }
   return alignment;
+}
+
+function replaceGeneralTag(lineContent) {
+  lineContent = lineContent.replace(/<general>\*/, ''); // removes <general>*
+  lineContent = lineContent.replace(/<\/general>/, ''); // removes </general>
+  return lineContent;
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ exports.getLineHTMLForExport = function(hook, context) {
   var alignment = _analyzeLine(context.attribLine, context.apool);
   var lineContent = context.lineContent;
   if (alignment) {
-    context.lineContent = "<p style='text-align:" + alignment + "'>" + replaceGeneralTag(lineContent) + "</p>";
+    context.lineContent = `<align-${alignment}>${lineContent.substring(1)}</align-${alignment}>`;
+    context.lineAttribsProcessed = true;
   }
 };
 
@@ -25,10 +26,4 @@ function _analyzeLine(alineAttrs, apool) {
     }
   }
   return alignment;
-}
-
-function replaceGeneralTag(lineContent) {
-  lineContent = lineContent.replace(/<general>\*/, ''); // removes <general>*
-  lineContent = lineContent.replace(/<\/general>/, ''); // removes </general>
-  return lineContent;
 }


### PR DESCRIPTION
This PR fixes the case when a line with alignment has styles, such as bold, italic, underline. The previous implementation did not allow us to export these tags to HTML.

Implements part of the [card 2237](https://trello.com/c/FrbBtWRx).